### PR TITLE
Update Docker repository key handling

### DIFF
--- a/ansible/roles/install_docker/tasks/main.yml
+++ b/ansible/roles/install_docker/tasks/main.yml
@@ -12,14 +12,21 @@
       state: latest
       update_cache: yes
 
-  - name: Add GPG key
-    apt_key:
+  - name: Ensure /etc/apt/keyrings exists
+    file:
+      path: /etc/apt/keyrings
+      state: directory
+      mode: '0755'
+
+  - name: Download Docker GPG key
+    ansible.builtin.get_url:
       url: "https://download.docker.com/linux/{{ 'debian' if ansible_distribution | lower == 'debian' else 'ubuntu' }}/gpg"
-      state: present
+      dest: /etc/apt/keyrings/docker.asc
+      mode: '0644'
 
   - name: Add Docker repository
     apt_repository:
-      repo: "deb [arch=amd64] https://download.docker.com/linux/{{ 'debian' if ansible_distribution | lower == 'debian' else 'ubuntu' }} {{ ansible_distribution_release }} stable"
+      repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ 'debian' if ansible_distribution | lower == 'debian' else 'ubuntu' }} {{ ansible_distribution_release }} stable"
       state: present
 
   - name: Install Docker
@@ -39,4 +46,3 @@
       append: yes
     loop:
       - "{{ ansible_user }}"
-


### PR DESCRIPTION
## Summary
- ensure the apt keyring directory exists before installing Docker packages
- download Docker's GPG key to /etc/apt/keyrings/docker.asc with the recommended permissions
- configure the Docker apt repository to reference the key file instead of apt_key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0cd317bc88330ae69ed42a8d8aae5