### PR TITLE
Clean up Docker apt repository definition

### DIFF
--- a/ansible/roles/install_docker/tasks/main.yml
+++ b/ansible/roles/install_docker/tasks/main.yml
@@ -24,10 +24,17 @@
       dest: /etc/apt/keyrings/docker.asc
       mode: '0644'
 
+  - name: Remove legacy Docker repository definition
+    ansible.builtin.apt_repository:
+      repo: "deb [arch=amd64] https://download.docker.com/linux/{{ 'debian' if ansible_distribution | lower == 'debian' else 'ubuntu' }} {{ ansible_distribution_release }} stable"
+      state: absent
+      filename: docker
+
   - name: Add Docker repository
     apt_repository:
       repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ 'debian' if ansible_distribution | lower == 'debian' else 'ubuntu' }} {{ ansible_distribution_release }} stable"
       state: present
+      filename: docker
 
   - name: Install Docker
     apt:


### PR DESCRIPTION
## Summary
- remove the legacy Docker apt repository entry so it can be recreated with a signed-by directive
- ensure the refreshed Docker repository uses the same sources list filename

## Testing
- not run (requires target infrastructure)


------
https://chatgpt.com/codex/tasks/task_b_68e0d10bf38883308b88b759f8699b83