### PR TITLE
Fix docker group assignment fallback

### DIFF
--- a/ansible/roles/install_docker/tasks/main.yml
+++ b/ansible/roles/install_docker/tasks/main.yml
@@ -51,5 +51,4 @@
       name: '{{ item }}'
       groups: docker
       append: yes
-    loop:
-      - "{{ ansible_user }}"
+    loop: "{{ [ansible_user | default(ansible_user_id)] | union(install_docker_extra_users | default([])) }}"


### PR DESCRIPTION
## Summary
- ensure the Docker group assignment task falls back to `ansible_user_id` when `ansible_user` is undefined
- support adding extra Docker group members via the optional `install_docker_extra_users` list variable

## Testing
- ansible-playbook -i inventory.ini 1_install_docker.yml *(fails: `ansible-playbook` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e0d2d36d9883308b383774adf6775b