### PR TITLE
Add optional certificate validation for Nexus health check

### DIFF
--- a/ansible/roles/install_nexus/tasks/main.yml
+++ b/ansible/roles/install_nexus/tasks/main.yml
@@ -212,6 +212,7 @@
     uri:
       url: "https://{{ nexus_server_name }}/"
       method: GET
+      validate_certs: "{{ not nexus_certbot_staging }}"
     register: _result
     until: _result.status == 200
     retries: 20  # retry X times  


### PR DESCRIPTION
## Summary
- disable TLS certificate validation for the Nexus health check when Certbot staging certificates are in use

## Testing
- ❌ `ansible-playbook -i inventory.ini 1_install_docker.yml 2_install_nexus.yml` (fails: ansible-playbook: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68e0d6ce11c48330b835c922c60423bf