### PR TITLE
Normalize Portainer/Nexus alias handling for multiple hostnames

### DIFF
--- a/ansible/group_vars/template_all.yml
+++ b/ansible/group_vars/template_all.yml
@@ -1,6 +1,22 @@
 # === Nexus
 nexus_docker_image: sonatype/nexus3:3.56.0
+nexus_docker_compose_location: /srv/nexus
+nexus_data_directory: "{{ nexus_docker_compose_location }}/nexus-data"
 nexus_autoconfiguration: true
+
+
+# === Portainer
+portainer_enabled: false
+portainer_image: portainer/portainer-ce:latest
+portainer_host_port: 9443
+portainer_data_directory: "{{ nexus_docker_compose_location }}/portainer-data"
+portainer_use_nginx_proxy: false
+portainer_server_name: docker.chnch.us
+# Example:
+# portainer_server_alias:
+#   - d.chnch.us
+portainer_server_alias: []
+portainer_backend_port: 9000
 
 
 # === Nginx
@@ -9,8 +25,10 @@ nexus_backend_name: nexus
 nexus_host_port: 8081
 nexus_backend_port: 8081
 nexus_server_name: nexus.example.org
-# Example: nexus_server_alias: repo.example.org
-nexus_server_alias: 
+# Example:
+# nexus_server_alias:
+#   - repo.example.org
+nexus_server_alias: []
 
 
 # == Let's Encrypt

--- a/ansible/roles/install_nexus/defaults/main.yml
+++ b/ansible/roles/install_nexus/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 nexus_docker_compose_template: templates/nexus-docker-compose.yml.j2
 nexus_docker_compose_location: /srv/nexus
+nexus_data_directory: "{{ nexus_docker_compose_location }}/nexus-data"
 nexus_docker_compose_file_name: docker-compose.yml
 nexus_docker_compose_command: docker compose
 
@@ -12,3 +13,12 @@ nexus_autoconfiguration_sh_template: templates/nexus-autoconfiguration.sh.j2
 nexus_autoconfiguration_sh_file_name: nexus-autoconfiguration.sh
 
 nginx_conf_file: templates/nginx.conf.j2
+
+portainer_enabled: false
+portainer_image: portainer/portainer-ce:latest
+portainer_host_port: 9443
+portainer_data_directory: "{{ nexus_docker_compose_location }}/portainer-data"
+portainer_use_nginx_proxy: false
+portainer_server_name: ""
+portainer_server_alias: []
+portainer_backend_port: 9000

--- a/ansible/roles/install_nexus/tasks/main.yml
+++ b/ansible/roles/install_nexus/tasks/main.yml
@@ -13,18 +13,6 @@
       group: root
       mode: 0644
 
-  - name: Make up server alias parameters string
-    set_fact:
-       aliases: "{{ nexus_server_alias.split() | join(' -d ') }}"
-    when: nexus_server_alias
-
-  - name: Update server aliases in certbot command in the docker-compose file
-    replace:
-      path: "{{ nexus_docker_compose_location }}/{{ nexus_docker_compose_file_name }}"
-      regexp: '(^\s*command: certonly .*) -d .*'
-      replace: '\1 -d {{ nexus_server_name }} -d {{ aliases }}'
-    when: nexus_server_alias
-
   - name: Enable Lets Encrypt staging mode in certbot command in the docker-compose file
     replace:
       path: "{{ nexus_docker_compose_location }}/{{ nexus_docker_compose_file_name }}"
@@ -39,13 +27,22 @@
       replace: '\1 \3'
     when: not nexus_certbot_staging
 
-  - name: Create Nexus data directory {{ nexus_docker_compose_location }}/nexus-data
+  - name: Create Nexus data directory {{ nexus_data_directory }}
     file:
-      path: "{{ nexus_docker_compose_location }}/nexus-data"
+      path: "{{ nexus_data_directory }}"
       state: directory
       owner: 200
       group: 200
       mode: 0755
+
+  - name: Create Portainer data directory {{ portainer_data_directory }}
+    file:
+      path: "{{ portainer_data_directory }}"
+      state: directory
+      owner: root
+      group: root
+      mode: 0755
+    when: portainer_enabled | bool
   when: nexus_docker_compose_location|default("") != ""
 
 
@@ -111,21 +108,21 @@
 - block:
   - name: Check if Nexus properties file exists
     stat:
-      path: "{{ nexus_docker_compose_location }}/nexus-data/etc/nexus.properties"
+      path: "{{ nexus_data_directory }}/etc/nexus.properties"
     register: nexus_properties_file
 
-  - name: Create "{{ nexus_docker_compose_location }}/nexus-data/etc" directory
+  - name: Create "{{ nexus_data_directory }}/etc" directory
     file:
-      path: "{{ nexus_docker_compose_location }}/nexus-data/etc"
+      path: "{{ nexus_data_directory }}/etc"
       state: directory
       owner: 200
       group: 200
       mode: 0755
     when: not nexus_properties_file.stat.exists
 
-  - name: Create "{{ nexus_docker_compose_location }}/nexus-data/etc/nexus.properties" file
+  - name: Create "{{ nexus_data_directory }}/etc/nexus.properties" file
     file:
-      path: "{{ nexus_docker_compose_location }}/nexus-data/etc/nexus.properties"
+      path: "{{ nexus_data_directory }}/etc/nexus.properties"
       state: touch
       owner: 200
       group: 200
@@ -134,7 +131,7 @@
 
   - name: Enable Nexus REST API creation features
     lineinfile:
-      path: "{{ nexus_docker_compose_location }}/nexus-data/etc/nexus.properties"
+      path: "{{ nexus_data_directory }}/etc/nexus.properties"
       regexp: '^nexus.scripts.allowCreation='
       line: nexus.scripts.allowCreation=true
   when: nexus_autoconfiguration|default("") == true

--- a/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
+++ b/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
@@ -1,3 +1,27 @@
+{% set nexus_aliases = [] %}
+{% if nexus_server_alias %}
+  {% if nexus_server_alias is string %}
+    {% set _ = nexus_aliases.append(nexus_server_alias) %}
+  {% else %}
+    {% for alias in nexus_server_alias %}
+      {% if alias %}
+        {% set _ = nexus_aliases.append(alias) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+{% set portainer_aliases = [] %}
+{% if portainer_server_alias %}
+  {% if portainer_server_alias is string %}
+    {% set _ = portainer_aliases.append(portainer_server_alias) %}
+  {% else %}
+    {% for alias in portainer_server_alias %}
+      {% if alias %}
+        {% set _ = portainer_aliases.append(alias) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
 version: '3.5'
 
 services:
@@ -9,7 +33,7 @@ services:
     ports:
       - {{ nexus_host_port | default(8081) }}:{{ nexus_backend_port }}
     volumes:
-      - /srv/nexus/nexus-data:/nexus-data
+      - {{ nexus_data_directory }}:/nexus-data
 
   nginx:
     restart: unless-stopped
@@ -21,20 +45,50 @@ services:
     depends_on:
       - nexus
     volumes:
-      - /srv/nexus/nginx-conf:/etc/nginx/conf.d
-      - /srv/nexus/dhparam/dhparam-2048.pem:/etc/ssl/certs/dhparam-2048.pem
-      - /srv/nexus/letsencrypt:/etc/letsencrypt
-      - /srv/nexus/web-root:/var/www/html
+      - {{ nexus_docker_compose_location }}/nginx-conf:/etc/nginx/conf.d
+      - {{ nexus_docker_compose_location }}/dhparam/dhparam-2048.pem:/etc/ssl/certs/dhparam-2048.pem
+      - {{ nexus_docker_compose_location }}/letsencrypt:/etc/letsencrypt
+      - {{ nexus_docker_compose_location }}/web-root:/var/www/html
 
   certbot:
     image: certbot/certbot
     container_name: certbot
     volumes:
-      - /srv/nexus/letsencrypt:/etc/letsencrypt
-      - /srv/nexus/web-root:/var/www/html
+      - {{ nexus_docker_compose_location }}/letsencrypt:/etc/letsencrypt
+      - {{ nexus_docker_compose_location }}/web-root:/var/www/html
     depends_on:
       - nginx
-    command: certonly --staging --webroot --webroot-path=/var/www/html --email {{ nexus_certbot_email }} --agree-tos --no-eff-email --force-renewal -d {{ nexus_server_name }}
+{% set cert_domains = [] %}
+{% if nexus_server_name %}
+  {% set _ = cert_domains.append(nexus_server_name) %}
+{% endif %}
+{% for alias in nexus_aliases %}
+  {% set _ = cert_domains.append(alias) %}
+{% endfor %}
+{% if portainer_use_nginx_proxy | bool and portainer_server_name %}
+  {% set _ = cert_domains.append(portainer_server_name) %}
+  {% for alias in portainer_aliases %}
+    {% set _ = cert_domains.append(alias) %}
+  {% endfor %}
+{% endif %}
+{% set cert_domains = cert_domains | unique %}
+    command: certonly --staging --webroot --webroot-path=/var/www/html --email {{ nexus_certbot_email }} --agree-tos --no-eff-email --force-renewal{% for domain in cert_domains %} -d {{ domain }}{% endfor %}
+
+{% if portainer_enabled | bool %}
+  portainer:
+    restart: unless-stopped
+    container_name: portainer
+    image: {{ portainer_image }}
+{% if not portainer_use_nginx_proxy | bool %}
+    ports:
+      - {{ portainer_host_port }}:9443
+{% endif %}
+    expose:
+      - "{{ portainer_backend_port }}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - {{ portainer_data_directory }}:/data
+{% endif %}
       
 networks:
   default:

--- a/ansible/roles/install_nexus/templates/nginx.conf.j2
+++ b/ansible/roles/install_nexus/templates/nginx.conf.j2
@@ -1,7 +1,64 @@
+{% set nexus_aliases = [] %}
+{% if nexus_server_alias %}
+  {% if nexus_server_alias is string %}
+    {% set _ = nexus_aliases.append(nexus_server_alias) %}
+  {% else %}
+    {% for alias in nexus_server_alias %}
+      {% if alias %}
+        {% set _ = nexus_aliases.append(alias) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+{% set portainer_aliases = [] %}
+{% if portainer_server_alias %}
+  {% if portainer_server_alias is string %}
+    {% set _ = portainer_aliases.append(portainer_server_alias) %}
+  {% else %}
+    {% for alias in portainer_server_alias %}
+      {% if alias %}
+        {% set _ = portainer_aliases.append(alias) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+{% set nexus_server_names = [] %}
+{% if nexus_server_name %}
+  {% set _ = nexus_server_names.append(nexus_server_name) %}
+{% endif %}
+{% for alias in nexus_aliases %}
+  {% set _ = nexus_server_names.append(alias) %}
+{% endfor %}
+{% set nexus_server_names = nexus_server_names | unique %}
+{% set portainer_server_names = [] %}
+{% if portainer_server_name %}
+  {% set _ = portainer_server_names.append(portainer_server_name) %}
+{% endif %}
+{% for alias in portainer_aliases %}
+  {% set _ = portainer_server_names.append(alias) %}
+{% endfor %}
+{% set portainer_server_names = portainer_server_names | unique %}
+
 server {
         listen 80;
         listen [::]:80;
-        server_name {{ nexus_server_name }} {{ nexus_server_alias }};
+        server_name {{ nexus_server_names | join(' ') }};
+
+        location ~ /.well-known/acme-challenge {
+          allow all;
+          root /var/www/html;
+        }
+
+        location / {
+                rewrite ^ https://$host$request_uri? permanent;
+        }
+}
+
+{% if portainer_use_nginx_proxy | bool and portainer_server_name %}
+server {
+        listen 80;
+        listen [::]:80;
+        server_name {{ portainer_server_names | join(' ') }};
 
         location ~ /.well-known/acme-challenge {
           allow all;
@@ -16,7 +73,52 @@ server {
 server {
         listen 443 ssl http2;
         listen [::]:443 ssl http2;
-        server_name {{ nexus_server_name }} {{ nexus_server_alias }};
+        server_name {{ portainer_server_names | join(' ') }};
+
+        proxy_send_timeout        120;
+        proxy_read_timeout        300;
+        proxy_buffering           off;
+        keepalive_timeout         5 5;
+        tcp_nodelay               on;
+
+        server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/{{ nexus_server_name }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ nexus_server_name }}/privkey.pem;
+
+        ssl_buffer_size 8k;
+
+        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+        ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+        ssl_prefer_server_ciphers on;
+
+        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+
+        ssl_ecdh_curve secp384r1;
+        ssl_session_tickets off;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 127.0.0.11 ipv6=off;
+
+        location / {
+             proxy_http_version 1.1;
+             proxy_set_header Upgrade $http_upgrade;
+             proxy_set_header Connection "upgrade";
+             proxy_set_header Host $host:$server_port;
+             proxy_set_header X-Real-IP $remote_addr;
+             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+             proxy_set_header X-Forwarded-Proto "https";
+             proxy_pass http://portainer:{{ portainer_backend_port }};
+        }
+}
+{% endif %}
+
+server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name {{ nexus_server_names | join(' ') }};
 
         proxy_send_timeout        120;
         proxy_read_timeout        300;


### PR DESCRIPTION
## Summary
- allow the Nexus and Portainer alias variables to be provided as YAML lists and normalize them before rendering compose and Nginx configs
- update role defaults and sample group vars to default the alias settings to empty lists for clarity
- document the list-based alias configuration in the README and expand the Portainer proxy instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0e40cf4888330a7a87d4c1e468db4