### PR TITLE
Trim whitespace-only output ahead of compose version

### DIFF
--- a/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
+++ b/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
@@ -1,41 +1,41 @@
-{% set nexus_aliases = [] %}
-{% if nexus_server_alias %}
-  {% if nexus_server_alias is string %}
-    {% set _ = nexus_aliases.append(nexus_server_alias) %}
-  {% else %}
-    {% for alias in nexus_server_alias %}
-      {% if alias %}
-        {% set _ = nexus_aliases.append(alias) %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endif %}
-{% set portainer_aliases = [] %}
-{% if portainer_server_alias %}
-  {% if portainer_server_alias is string %}
-    {% set _ = portainer_aliases.append(portainer_server_alias) %}
-  {% else %}
-    {% for alias in portainer_server_alias %}
-      {% if alias %}
-        {% set _ = portainer_aliases.append(alias) %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endif %}
-{% set cert_domains = [] %}
-{% if nexus_server_name %}
-  {% set _ = cert_domains.append(nexus_server_name) %}
-{% endif %}
-{% for alias in nexus_aliases %}
-  {% set _ = cert_domains.append(alias) %}
-{% endfor %}
-{% if portainer_use_nginx_proxy | bool and portainer_server_name %}
-  {% set _ = cert_domains.append(portainer_server_name) %}
-  {% for alias in portainer_aliases %}
-    {% set _ = cert_domains.append(alias) %}
-  {% endfor %}
-{% endif %}
-{% set cert_domains = cert_domains | unique %}
+{%- set nexus_aliases = [] %}
+{%- if nexus_server_alias %}
+  {%- if nexus_server_alias is string %}
+    {%- set _ = nexus_aliases.append(nexus_server_alias) %}
+  {%- else %}
+    {%- for alias in nexus_server_alias %}
+      {%- if alias %}
+        {%- set _ = nexus_aliases.append(alias) %}
+      {%- endif %}
+    {%- endfor %}
+  {%- endif %}
+{%- endif %}
+{%- set portainer_aliases = [] %}
+{%- if portainer_server_alias %}
+  {%- if portainer_server_alias is string %}
+    {%- set _ = portainer_aliases.append(portainer_server_alias) %}
+  {%- else %}
+    {%- for alias in portainer_server_alias %}
+      {%- if alias %}
+        {%- set _ = portainer_aliases.append(alias) %}
+      {%- endif %}
+    {%- endfor %}
+  {%- endif %}
+{%- endif %}
+{%- set cert_domains = [] %}
+{%- if nexus_server_name %}
+  {%- set _ = cert_domains.append(nexus_server_name) %}
+{%- endif %}
+{%- for alias in nexus_aliases %}
+  {%- set _ = cert_domains.append(alias) %}
+{%- endfor %}
+{%- if portainer_use_nginx_proxy | bool and portainer_server_name %}
+  {%- set _ = cert_domains.append(portainer_server_name) %}
+  {%- for alias in portainer_aliases %}
+    {%- set _ = cert_domains.append(alias) %}
+  {%- endfor %}
+{%- endif %}
+{%- set cert_domains = cert_domains | unique %}
 version: '3.5'
 
 services:


### PR DESCRIPTION
## Summary
- suppress whitespace emitted by the Jinja control flow that prepares the certbot domain list
- ensure the rendered docker-compose file now starts directly with the version stanza for docker compose parsing

## Testing
- not run (not covered by automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68e1124968208330864c68ac696d56ff