### PR TITLE
Fix whitespace in Nexus docker compose template

### DIFF
--- a/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
+++ b/ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
 {% set nexus_aliases = [] %}
 {% if nexus_server_alias %}
   {% if nexus_server_alias is string %}


### PR DESCRIPTION
## Summary
- enable Jinja whitespace trimming in the docker-compose template so the rendered file begins at column zero

## Testing
- ansible localhost -c local -i localhost, -m template -a "src=ansible/roles/install_nexus/templates/nexus-docker-compose.yml.j2 dest=/tmp/nexus-docker-compose.yml" -e @ansible/group_vars/template_all.yml


------
https://chatgpt.com/codex/tasks/task_b_68e114a7a5d4833085c6bc875eafdecf