### PR TITLE
Update Portainer host header in nginx template

### DIFF
--- a/ansible/roles/install_nexus/templates/nginx.conf.j2
+++ b/ansible/roles/install_nexus/templates/nginx.conf.j2
@@ -106,7 +106,8 @@ server {
              proxy_http_version 1.1;
              proxy_set_header Upgrade $http_upgrade;
              proxy_set_header Connection "upgrade";
-             proxy_set_header Host $host:$server_port;
+             proxy_set_header Host $host;
+             proxy_set_header X-Forwarded-Port $server_port;
              proxy_set_header X-Real-IP $remote_addr;
              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
              proxy_set_header X-Forwarded-Proto "https";


### PR DESCRIPTION
## Summary
- update the Portainer proxy Host header to avoid appending the server port
- add an X-Forwarded-Port header so downstream services can detect the listener port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e11e1484d483308758c95800320d72